### PR TITLE
WIP: Fix synthesis agent calibration — single medium finding should trigger needs_changes

### DIFF
--- a/skills/code-review/agents/synthesis.md
+++ b/skills/code-review/agents/synthesis.md
@@ -37,7 +37,7 @@ Apply these rules to merge findings:
 Rank findings by severity:
 1. `critical` — Must be fixed before merge
 2. `high` — Should be fixed before merge
-3. `medium` — Address if time permits
+3. `medium` — Should be fixed — actionable and meaningful
 4. `low` — Nice to have
 
 ## Recommendation Rules
@@ -45,8 +45,8 @@ Rank findings by severity:
 Determine the overall recommendation:
 
 - **`blocked`** — Any `critical` finding exists
-- **`needs_changes`** — Any `high` finding exists, OR 2+ `medium` findings, OR any agent status is `failed`
-- **`approved`** — No `critical` or `high` findings, all agents `passed` or `warning`
+- **`needs_changes`** — Any `high` finding exists, OR any `medium` finding exists, OR any agent status is `failed`
+- **`approved`** — No `critical`, `high`, or `medium` findings (only `low`/`info`). All agents `passed` or `warning`
 
 ## Output Format
 


### PR DESCRIPTION
# Fix Synthesis Agent Calibration

**Issue:** https://github.com/cristoslc/code-review-skill/issues/2

## Problem

The synthesis agent prompt in `agents/synthesis.md` lets a single `medium` actionable finding slip through to `approved` instead of triggering `needs_changes`. The rubric requires "2+ medium" for `needs_changes`, but any actionable medium finding should block approval.

## Fix

Two changes to `skills/code-review/agents/synthesis.md`:

1. **Recommendation rules** — Change `needs_changes` to trigger on **any** `medium`+ finding (not 2+):
   - `blocked` — Any `critical` finding
   - `needs_changes` — Any `high` **OR any `medium`** finding, OR any agent status is `failed`
   - `approved` — No `critical`, `high`, or `medium` findings (only `low`/`info`)

2. **Severity ranking** — Update `medium` description from "Address if time permits" to "Should be fixed — actionable and meaningful" to match the stricter threshold.

## Files

- `skills/code-review/agents/synthesis.md` — update severity ranking + recommendation rules